### PR TITLE
Add license information

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     version="1.0.10",
     author="Palazzetti Lelio Spa",
     author_email="info@palazzetti.it",
+    license="MIT",
     description="IoT Device Capability Parser",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
I am working on an HomeAssistant integration. Homeassistant has a strict opensource policy and is checking the license metadata of all the imported packages. This package is published under an MIT license, and including that metadata will help unblock the integration. It would be awesome if you could make a new release with this PR.